### PR TITLE
Set basic mode

### DIFF
--- a/aldn1000Sup/aldn1000.db
+++ b/aldn1000Sup/aldn1000.db
@@ -448,6 +448,7 @@ record(bo, "$(P)_SET_BASIC_MODE")
     field(DTYP, "stream")
 
     field(OUT,  "@aldn1000.proto setBasicMode $(PORT)")
+#    field(OUT,  "@aldn1000.proto setBasicModeEx($(P),ID) $(PORT)")
     field(PINI, "YES")
 }
 

--- a/aldn1000Sup/aldn1000.db
+++ b/aldn1000Sup/aldn1000.db
@@ -440,6 +440,18 @@ record(mbbi, "$(P)PROGRAM:FUNCTION")
     field(SDIS, "$(P)DISABLE")
 }
 
+# set basic mode (as opposed to safe mode)
+record(bo, "$(P)_SET_BASIC_MODE")
+{
+    field(DESC, "Set basic comm mode")
+    field(SCAN, "Passive")
+    field(DTYP, "stream")
+
+    field(OUT,  "@aldn1000.proto setBasicMode $(PORT)")
+    field(PINI, "YES")
+}
+
+
 ### SIMULATION RECORDS ###
 
 record(bo,"$(P)SIM:STOP:SP")

--- a/aldn1000Sup/aldn1000.proto
+++ b/aldn1000Sup/aldn1000.proto
@@ -112,3 +112,9 @@ getProgFunc {
     in STX "%*" $id "%*" $status_modes "%{RAT|INC|DEC}";
     @mismatch { mismatch_catcher; }
 }
+
+# change back from safe mode to basic mode
+setBasicMode {
+    OutTerminator = ETX;
+    out STX 0x08 "SAF0" 0x55 0x43;
+}

--- a/aldn1000Sup/aldn1000.proto
+++ b/aldn1000Sup/aldn1000.proto
@@ -114,7 +114,18 @@ getProgFunc {
 }
 
 # change back from safe mode to basic mode
+# probably assumes pump address 0
 setBasicMode {
     OutTerminator = ETX;
     out STX 0x08 "SAF0" 0x55 0x43;
+}
+
+# more complex version using address
+# stream device has 3 implementation of ccitt16 checksum, need to check which works here
+# 0x55 0x43 above are checksum of "SAF0" so may be able to use that to test which stream device checksum is appropriate
+# below we need to checksum the address followed by SAF0
+# use 02d for address so it is always 2 bytes, this is because the item after STX is length and it allows us to fix at 0xA 
+setBasicModeEx {
+    OutTerminator = ETX;
+    out STX 0xA "%(\$1\$2)02d" "SAF0" %2<ccitt16>;
 }


### PR DESCRIPTION
Add functions to swap from safe to basic mode

if setBasicModeEx is needed (maybe if device has address != 0, but not clear from docs), then probably need to experiment with which of the several `ccitt16` checksum implementations available in stream device is the one used by the device

See ISISComputingGroup/IBEX#6422